### PR TITLE
added user_sorted_content table to models and schema

### DIFF
--- a/cassiopeia/models/models.py
+++ b/cassiopeia/models/models.py
@@ -79,6 +79,13 @@ locale = db.Table('locale',
     db.Column('country_code', db.String(3), db.ForeignKey('country.alpha3code'), nullable=False)
 )
 
+# User sorted content (many-to-many relationship for user and content)
+user_sorted_content = db.Table('user_sorted_content',
+        db.Column('user_id', db.Integer, db.ForeignKey('user.id'), nullable=False),
+        db.Column('content_id', db.Integer, db.ForeignKey('content.id'), nullable=False),
+        db.Column('sorted_value', db.Integer, nullable=False)
+)
+
 class UserLangSkill(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True, nullable=False)
     language_id = db.Column(db.Integer, db.ForeignKey('language.id'), primary_key=True, nullable=False)

--- a/cassiopeia/models/schema.sql
+++ b/cassiopeia/models/schema.sql
@@ -62,6 +62,20 @@ CREATE TABLE user_language_skill (
     ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
+CREATE TABLE user_sorted_content (
+  UserID int NOT NULL,
+  LanguageID int NOT NULL,
+  SortedLvl int NOT NULL,
+
+  FOREIGN KEY (UserID) 
+    REFERENCES users(ID)
+    ON UPDATE CASCADE ON DELETE RESTRICT,
+
+  FOREIGN KEY (LanguageID) 
+    REFERENCES language(ID) 
+    ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
 CREATE TABLE content_category (
   ContentID int NOT NULL,
   CategoryID int NOT NULL

--- a/cassiopeia/models/schema.sql
+++ b/cassiopeia/models/schema.sql
@@ -64,15 +64,15 @@ CREATE TABLE user_language_skill (
 
 CREATE TABLE user_sorted_content (
   UserID int NOT NULL,
-  LanguageID int NOT NULL,
-  SortedLvl int NOT NULL,
+  ContentID int NOT NULL,
+  SortedSkill int NOT NULL,
 
   FOREIGN KEY (UserID) 
     REFERENCES users(ID)
     ON UPDATE CASCADE ON DELETE RESTRICT,
 
-  FOREIGN KEY (LanguageID) 
-    REFERENCES language(ID) 
+  FOREIGN KEY (ContentID) 
+    REFERENCES content(ID) 
     ON UPDATE CASCADE ON DELETE RESTRICT
 );
 


### PR DESCRIPTION
Added user_sorted_content to models.py and schema.sql. Also manually added to cassiopeia_prod using mysql client. New table has three columns: user_id, content_id, sortedSkill. All fields are of type INT.